### PR TITLE
expose NonNativeTarget's value field for external usage

### DIFF
--- a/src/gadgets/nonnative.rs
+++ b/src/gadgets/nonnative.rs
@@ -25,7 +25,7 @@ use crate::gadgets::biguint::{
 
 #[derive(Clone, Debug)]
 pub struct NonNativeTarget<FF: Field> {
-    pub(crate) value: BigUintTarget,
+    pub value: BigUintTarget,
     pub(crate) _phantom: PhantomData<FF>,
 }
 


### PR DESCRIPTION
(small PR to be able to access the `NonNativeTarget.value` from outside this library)